### PR TITLE
Sort results by the order of their IDs

### DIFF
--- a/lib/active_admin_auto_select.rb
+++ b/lib/active_admin_auto_select.rb
@@ -27,7 +27,11 @@ module AutoSelectable
            resources = effective_scope.call.
              where("#{resource.table_name}.id IN (?)", params[:ids]).
              select(select_fields)
-           resources = resources.first if resources.size == 1
+           if resources.size == 1
+             resources = resources.first
+           else
+             resources = resources.sort_by { |r| params[:ids].index(r.id.to_s) }
+           end
            render json: resources and return
         else
           concat_fields = fields.join(" || ' '::text || ")


### PR DESCRIPTION
When passing `params[:ids]` array, the returned array will now have the
same order as the passed IDs.

This is useful when retrieving records for a select2 field.
